### PR TITLE
Fix User Assignment in Wallet Creation

### DIFF
--- a/wallet/views.py
+++ b/wallet/views.py
@@ -22,7 +22,7 @@ def create_wallet(request):
     encrypted_secret_seed = keypair.secret
     encrypted_secret_seed = cryptocode.encrypt(keypair.secret, encryption_key)
     wallet = Wallet.objects.create(
-        user=User.objects.first(),
+        user=request.user,
         public_key=keypair.public_key,
         secret_seed=encrypted_secret_seed
     )


### PR DESCRIPTION
Fixes #1

## Problem
`create_wallet` was assigning every new wallet to `User.objects.first()` 
instead of the currently logged-in user, causing all wallets to be 
linked to the same user regardless of who is authenticated.

## Fix
Changed `User.objects.first()` to `request.user` in `wallet/views.py`.

## Changes
- `wallet/views.py` — line 26